### PR TITLE
Feature/separating caching

### DIFF
--- a/stock-consultant/src/main/java/com/emeraldhieu/cache/CacheService.java
+++ b/stock-consultant/src/main/java/com/emeraldhieu/cache/CacheService.java
@@ -10,10 +10,8 @@ import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.springframework.stereotype.Component;
 
-import com.emeraldhieu.closeprice.ClosePrice;
-
 @Component
-public class CacheService {
+public class CacheService<T> {
     /**
      * Store 10000 frequently used elements.
      */
@@ -21,28 +19,27 @@ public class CacheService {
 
     private CacheManager cacheManager;
 
-    /**
-     * Map of hashCode and dateClose. To get a dateClose, pass hashCode.
-     */
-    private Cache<String, ClosePrice.Price> dateCloseCache;
+    public static final String DEFAULT_CACHE_KEY = "default";
+
+    private Cache<String, CachedEntity> cache;
 
     @PostConstruct
     public void init() {
          cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
-                .withCache("dateClose",
-                        CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, ClosePrice.Price.class,
+                .withCache(DEFAULT_CACHE_KEY,
+                        CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, CachedEntity.class,
                                 ResourcePoolsBuilder.heap(MAX_ENTRY_COUNT)))
                  .build();
         cacheManager.init();
-        dateCloseCache = cacheManager.getCache("dateClose", String.class, ClosePrice.Price.class);
+        cache = cacheManager.getCache(DEFAULT_CACHE_KEY, String.class, CachedEntity.class);
     }
 
-    public ClosePrice.Price get(String key) {
-        return dateCloseCache.get(key);
+    public CachedEntity<T> get(String key) {
+        return cache.get(key);
     }
 
-    public void put(String key, ClosePrice.Price price) {
-        dateCloseCache.put(key, price);
+    public void put(String key, CachedEntity<T> value) {
+        cache.put(key, value);
     }
 
     @PreDestroy

--- a/stock-consultant/src/main/java/com/emeraldhieu/cache/CachedEntity.java
+++ b/stock-consultant/src/main/java/com/emeraldhieu/cache/CachedEntity.java
@@ -1,0 +1,10 @@
+package com.emeraldhieu.cache;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CachedEntity<T> {
+    private T entity;
+}

--- a/stock-consultant/src/main/java/com/emeraldhieu/closeprice/ClosePriceCache.java
+++ b/stock-consultant/src/main/java/com/emeraldhieu/closeprice/ClosePriceCache.java
@@ -1,0 +1,12 @@
+package com.emeraldhieu.closeprice;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface ClosePriceCache {
+    
+}

--- a/stock-consultant/src/main/java/com/emeraldhieu/closeprice/ClosePriceCacheFilter.java
+++ b/stock-consultant/src/main/java/com/emeraldhieu/closeprice/ClosePriceCacheFilter.java
@@ -1,0 +1,108 @@
+package com.emeraldhieu.closeprice;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import javax.annotation.Priority;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.Provider;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.emeraldhieu.cache.CacheService;
+import com.emeraldhieu.cache.CachedEntity;
+import com.emeraldhieu.closeprice.ClosePrice.Price;
+
+import lombok.extern.apachecommons.CommonsLog;
+
+@Component
+@Provider
+@CommonsLog
+@Priority(2000)
+public class ClosePriceCacheFilter extends DateCloseCacheFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    @Context
+    private ResourceInfo resourceInfo;
+
+    @Autowired
+    private CacheService<Price> cacheService;
+
+    private String ticker;
+    private String startDate;
+    private String endDate;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        ClosePriceCache closePriceCache = resourceInfo.getResourceMethod()
+                .getAnnotation(ClosePriceCache.class);
+        if (closePriceCache == null) {
+            return;
+        }
+
+        MultivaluedMap<String, String> queryParameters = requestContext.getUriInfo().getQueryParameters();
+        MultivaluedMap<String, String> pathParameters = requestContext.getUriInfo().getPathParameters();
+
+        ticker = Objects.toString(pathParameters.getFirst("ticker"), "");
+        startDate = Objects.toString(queryParameters.getFirst("startDate"), "");
+        endDate = Objects.toString(queryParameters.getFirst("endDate"), "");
+
+        // Get price from cache.
+        CachedEntity<Price> cachedPrice = cacheService.get(generateHashCode(ticker, startDate, endDate));
+
+        if (cachedPrice != null) {
+            log.debug("Retrieving cache of date close...");
+            Response response = Response.status(Status.OK)
+                    .type(requestContext.getMediaType())
+                    .entity(cachedPrice)
+                    .build();
+
+            requestContext.abortWith(response);
+        }
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        ClosePriceCache closePriceCache = resourceInfo.getResourceMethod()
+                .getAnnotation(ClosePriceCache.class);
+        if (closePriceCache == null) {
+            return;
+        }
+
+        if (responseContext.getStatusInfo() != Status.OK // If error occurs
+                || responseContext.getEntity() instanceof CachedEntity) { // or if a cache is being retrieved
+            return;
+        }
+
+        log.debug("Caching close price...");
+
+        ClosePrice closePrice = (ClosePrice) responseContext.getEntity();
+        Price price = closePrice.getPrices().get(0);
+        CachedEntity<Price> cachedPrice = CachedEntity.<Price>builder().entity(price).build();
+
+        // Cache the price!
+        cacheService.put(generateHashCode(ticker, startDate, endDate), cachedPrice);
+    }
+
+    /**
+     * Used for testing.
+     */
+    void setCacheService(CacheService cacheService) {
+        this.cacheService = cacheService;
+    }
+
+    /**
+     * Used for testing.
+     */
+    void setResourceInfo(ResourceInfo resourceInfo) {
+        this.resourceInfo = resourceInfo;
+    }
+}

--- a/stock-consultant/src/main/java/com/emeraldhieu/closeprice/ClosePriceService.java
+++ b/stock-consultant/src/main/java/com/emeraldhieu/closeprice/ClosePriceService.java
@@ -1,6 +1,5 @@
 package com.emeraldhieu.closeprice;
 
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -22,9 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.emeraldhieu.Config;
-import com.emeraldhieu.cache.CacheService;
 import com.emeraldhieu.errorhandler.ErrorHandlingService;
-import com.google.common.hash.Hashing;
 
 import lombok.extern.apachecommons.CommonsLog;
 import okhttp3.OkHttpClient;
@@ -40,9 +37,6 @@ public class ClosePriceService {
             Config.QUANDL_API_ENDPOINT + "%s/data.json?order=asc&column_index=4&start_date=%s&end_date=%s&api_key=" + Config.API_KEY;
 
     private OkHttpClient client = new OkHttpClient();
-
-    @Autowired
-    private CacheService cacheService;
 
     @Autowired
     private ErrorHandlingService errorHandlingService;
@@ -69,18 +63,6 @@ public class ClosePriceService {
         String startDate = Objects.toString(startDateParam, "");
         String endDate = Objects.toString(endDateParam, "");
 
-        // Get price from cache.
-        ClosePrice.Price cachedPrice = cacheService.get(generateHashCode(ticker, startDate, endDate));
-
-        // Return cached close price built from price.
-        if (cachedPrice != null) {
-            log.debug("Retrieving cache of close price...");
-            ClosePrice closePrice = ClosePrice.builder()
-                    .prices(Collections.singletonList(cachedPrice))
-                    .build();
-            return closePrice;
-        }
-
         String requestUri = String.format(GET_CLOSE_PRICE_URI_PATTERN, ticker, startDate, endDate);
         Request request = new Request.Builder().url(requestUri).build();
 
@@ -105,10 +87,6 @@ public class ClosePriceService {
                     .dateClose(dateCloseList)
                     .build();
 
-            // Cache the price!
-            log.debug("Caching close price...");
-            cacheService.put(generateHashCode(ticker, startDate, endDate), price);
-
             ClosePrice closePrice = ClosePrice.builder()
                     .prices(Collections.singletonList(price))
                     .build();
@@ -117,26 +95,11 @@ public class ClosePriceService {
         }
     }
 
-    public String generateHashCode(String ticker, String startDate, String endDate) {
-        String hashCode = Hashing.sha256()
-                .hashString(ticker + startDate + endDate,
-                        Charset.defaultCharset())
-                .toString();
-        return hashCode;
-    }
-
     /**
      * Used for testing.
      */
     void setClient(OkHttpClient client) {
         this.client = client;
-    }
-
-    /**
-     * Used for testing.
-     */
-    void setCacheService(CacheService cacheService) {
-        this.cacheService = cacheService;
     }
 
     /**

--- a/stock-consultant/src/main/java/com/emeraldhieu/closeprice/ClosePriceService.java
+++ b/stock-consultant/src/main/java/com/emeraldhieu/closeprice/ClosePriceService.java
@@ -56,6 +56,7 @@ public class ClosePriceService {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{ticker}/closePrice")
     @ClosePriceValidator
+    @ClosePriceCache
     public Object getClosePrice(@PathParam("ticker") String ticker,
                                 @QueryParam("startDate") String startDateParam,
                                 @QueryParam("endDate") String endDateParam) throws Exception {

--- a/stock-consultant/src/main/java/com/emeraldhieu/closeprice/DateCloseCacheFilter.java
+++ b/stock-consultant/src/main/java/com/emeraldhieu/closeprice/DateCloseCacheFilter.java
@@ -1,0 +1,18 @@
+package com.emeraldhieu.closeprice;
+
+import java.nio.charset.Charset;
+
+import javax.ws.rs.container.ContainerRequestFilter;
+
+import com.google.common.hash.Hashing;
+
+public abstract class DateCloseCacheFilter implements ContainerRequestFilter {
+
+    public String generateHashCode(String ticker, String startDate, String endDate) {
+        String hashCode = Hashing.sha256()
+                .hashString(ticker + startDate + endDate,
+                        Charset.defaultCharset())
+                .toString();
+        return hashCode;
+    }
+}

--- a/stock-consultant/src/main/java/com/emeraldhieu/multidmas/MultiDmaService.java
+++ b/stock-consultant/src/main/java/com/emeraldhieu/multidmas/MultiDmaService.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.emeraldhieu.Config;
-import com.emeraldhieu.cache.CacheService;
 import com.emeraldhieu.errorhandler.ErrorHandlingService;
 import com.emeraldhieu.twohundreddma.DmaService;
 import com.emeraldhieu.twohundreddma.DmaValidator;
@@ -42,9 +41,6 @@ public class MultiDmaService {
     private static final String NO_DATA_FOR_ANY_DATE = "There is no data for any date.";
 
     private OkHttpClient client = new OkHttpClient();
-
-    @Autowired
-    private CacheService cacheService;
 
     @Autowired
     private ErrorHandlingService errorHandlingService;
@@ -150,13 +146,6 @@ public class MultiDmaService {
                 .build();
 
         return multiDma;
-    }
-
-    /**
-     * Used for testing.
-     */
-    void setCacheService(CacheService cacheService) {
-        this.cacheService = cacheService;
     }
 
     /**

--- a/stock-consultant/src/main/java/com/emeraldhieu/twohundreddma/DmaCache.java
+++ b/stock-consultant/src/main/java/com/emeraldhieu/twohundreddma/DmaCache.java
@@ -1,0 +1,12 @@
+package com.emeraldhieu.twohundreddma;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface DmaCache {
+    
+}

--- a/stock-consultant/src/main/java/com/emeraldhieu/twohundreddma/DmaCacheFilter.java
+++ b/stock-consultant/src/main/java/com/emeraldhieu/twohundreddma/DmaCacheFilter.java
@@ -1,0 +1,107 @@
+package com.emeraldhieu.twohundreddma;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+import javax.annotation.Priority;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.Provider;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.emeraldhieu.cache.CacheService;
+import com.emeraldhieu.cache.CachedEntity;
+import com.emeraldhieu.closeprice.ClosePrice.Price;
+import com.emeraldhieu.closeprice.DateCloseCacheFilter;
+
+import lombok.extern.apachecommons.CommonsLog;
+
+@Component
+@Provider
+@CommonsLog
+@Priority(2000)
+public class DmaCacheFilter extends DateCloseCacheFilter implements ContainerRequestFilter {
+
+    @Context
+    private ResourceInfo resourceInfo;
+
+    @Autowired
+    private CacheService<Price> cacheService;
+
+    private String ticker;
+    private String startDate;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        DmaCache dmaCache = resourceInfo.getResourceMethod()
+                .getAnnotation(DmaCache.class);
+        if (dmaCache == null) {
+            return;
+        }
+
+        MultivaluedMap<String, String> queryParameters = requestContext.getUriInfo().getQueryParameters();
+        MultivaluedMap<String, String> pathParameters = requestContext.getUriInfo().getPathParameters();
+
+        ticker = Objects.toString(pathParameters.getFirst("ticker"), "");
+        startDate = Objects.toString(queryParameters.getFirst("startDate"), "");
+        if (startDate.isEmpty()) {
+            return;
+        }
+
+        // Get price from cache.
+        LocalDate startDateObj = LocalDate.parse(startDate, DateTimeFormatter.ISO_LOCAL_DATE);
+        LocalDate endDateObj = startDateObj.plusDays(200);
+        CachedEntity<Price> cachedPrice = cacheService.get(generateHashCode(ticker, startDate, endDateObj.format(DateTimeFormatter.ISO_LOCAL_DATE)));
+
+        if (cachedPrice != null) {
+            log.debug("Retrieving cache of date close...");
+
+            Price price = cachedPrice.getEntity();
+
+            TwoHundredDayMovingAverage.TwoHundredDma twoHundredDma = TwoHundredDayMovingAverage.TwoHundredDma.builder()
+                    .ticker(ticker)
+                    .avg(String.valueOf(getAverage(price)))
+                    .build();
+
+            TwoHundredDayMovingAverage twoHundredDayMovingAverage = TwoHundredDayMovingAverage.builder()
+                    .twoHundredDma(twoHundredDma).build();
+
+            Response response = Response.status(Status.OK)
+                    .type(requestContext.getMediaType())
+                    .entity(twoHundredDayMovingAverage)
+                    .build();
+
+            requestContext.abortWith(response);
+        }
+    }
+
+    public double getAverage(Price price) {
+        return price.getDateClose().stream()
+                .map(element -> element.get(1))
+                .mapToDouble(Double::parseDouble)
+                .average()
+                .getAsDouble();
+    }
+
+    /**
+     * Used for testing.
+     */
+    void setCacheService(CacheService cacheService) {
+        this.cacheService = cacheService;
+    }
+
+    /**
+     * Used for testing.
+     */
+    void setResourceInfo(ResourceInfo resourceInfo) {
+        this.resourceInfo = resourceInfo;
+    }
+}

--- a/stock-consultant/src/main/java/com/emeraldhieu/twohundreddma/DmaService.java
+++ b/stock-consultant/src/main/java/com/emeraldhieu/twohundreddma/DmaService.java
@@ -56,6 +56,7 @@ public class DmaService {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{ticker}/200dma")
     @DmaValidator
+    @DmaCache
     public Object get200DayMovingAverage(@PathParam("ticker") String ticker,
                                          @QueryParam("startDate") String startDateParam) throws Exception {
 
@@ -121,7 +122,8 @@ public class DmaService {
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(dataArray.iterator(), Spliterator.ORDERED), false)
                 .map(JSONArray.class::cast)
                 .mapToDouble(closePrice -> closePrice.getDouble(1))
-                .average().getAsDouble();
+                .average()
+                .getAsDouble();
     }
 
     /**

--- a/stock-consultant/src/main/java/com/emeraldhieu/twohundreddma/DmaValidationFilter.java
+++ b/stock-consultant/src/main/java/com/emeraldhieu/twohundreddma/DmaValidationFilter.java
@@ -3,6 +3,7 @@ package com.emeraldhieu.twohundreddma;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+import javax.annotation.Priority;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -18,6 +19,7 @@ import lombok.extern.apachecommons.CommonsLog;
 @Component
 @Provider
 @CommonsLog
+@Priority(1000)
 public class DmaValidationFilter implements ContainerRequestFilter {
 
     @Context

--- a/stock-consultant/src/test/java/com/emeraldhieu/AbstractServiceTest.java
+++ b/stock-consultant/src/test/java/com/emeraldhieu/AbstractServiceTest.java
@@ -1,13 +1,12 @@
 package com.emeraldhieu;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 
 import com.emeraldhieu.cache.CacheService;
-import com.emeraldhieu.closeprice.ClosePrice;
+import com.emeraldhieu.cache.CachedEntity;
 
 import okhttp3.Call;
 import okhttp3.MediaType;
@@ -38,12 +37,12 @@ public abstract class AbstractServiceTest {
 
     public class DummyCacheService extends CacheService {
         @Override
-        public ClosePrice.Price get(String key) {
+        public CachedEntity get(String key) {
             return null;
         }
 
         @Override
-        public void put(String key, ClosePrice.Price price) {
+        public void put(String key, CachedEntity value) {
             // Do nothing.
         }
     }

--- a/stock-consultant/src/test/java/com/emeraldhieu/closeprice/CacheFilterTest.java
+++ b/stock-consultant/src/test/java/com/emeraldhieu/closeprice/CacheFilterTest.java
@@ -1,0 +1,30 @@
+package com.emeraldhieu.closeprice;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class CacheFilterTest {
+
+    protected List<List<String>> dateCloseList;
+
+    public void setUp(String folder, String ticker) throws Exception {
+        Path responseFilePath = Paths.get(ClassLoader.getSystemResource("responses/" + folder + "/" + ticker + ".json").toURI());
+        String closePriceJsonResponse = new String(Files.readAllBytes(responseFilePath));
+        JSONObject jsonObject = new JSONObject(closePriceJsonResponse);
+        JSONObject datasetDataObject = jsonObject.getJSONObject("dataset_data");
+        JSONArray dataArray = datasetDataObject.getJSONArray("data");
+        Iterable<Object> iterable = () -> dataArray.iterator();
+        dateCloseList = StreamSupport.stream(iterable.spliterator(), false)
+                .map(JSONArray.class::cast)
+                .map(closePrice -> Arrays.asList(closePrice.getString(0), String.valueOf(closePrice.getDouble(1))))
+                .collect(Collectors.toList());
+    }
+}

--- a/stock-consultant/src/test/java/com/emeraldhieu/closeprice/CacheServiceTest.java
+++ b/stock-consultant/src/test/java/com/emeraldhieu/closeprice/CacheServiceTest.java
@@ -1,0 +1,40 @@
+package com.emeraldhieu.closeprice;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.emeraldhieu.cache.CacheService;
+import com.emeraldhieu.cache.CachedEntity;
+import com.emeraldhieu.closeprice.ClosePrice.Price;
+
+public class CacheServiceTest {
+
+    private CacheService cacheService;
+    private String ticker = "FB";
+
+    @Before
+    public void setUp() {
+        cacheService = new CacheService();
+        cacheService.init();
+    }
+
+    @Test
+    public void caching() {
+        // GIVEN
+        CachedEntity<Price> priceToCache = CachedEntity.<Price>builder()
+                .entity(Price.builder()
+                        .ticker(ticker)
+                        .build())
+                .build();
+
+        // WHEN
+        cacheService.put(CacheService.DEFAULT_CACHE_KEY, priceToCache);
+
+        // THEN
+        CachedEntity<Price> cachedPrice = cacheService.get(CacheService.DEFAULT_CACHE_KEY);
+        Price price = cachedPrice.getEntity();
+        assertEquals(ticker, price.getTicker());
+    }
+}

--- a/stock-consultant/src/test/java/com/emeraldhieu/closeprice/ClosePriceCacheFilterTest.java
+++ b/stock-consultant/src/test/java/com/emeraldhieu/closeprice/ClosePriceCacheFilterTest.java
@@ -1,0 +1,75 @@
+package com.emeraldhieu.closeprice;
+
+import static org.mockito.Mockito.*;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.emeraldhieu.cache.CacheService;
+import com.emeraldhieu.cache.CachedEntity;
+import com.emeraldhieu.closeprice.ClosePrice.Price;
+
+public class ClosePriceCacheFilterTest extends CacheFilterTest {
+
+    private ClosePriceCacheFilter closePriceCacheFilter;
+    private ResourceInfo resourceInfo;
+    private CacheService<Price> cacheService;
+    private ContainerRequestContext containerRequestContext;
+    private ContainerResponseContext containerResponseContext;
+    private String ticker = "FB";
+    private String startDate = "";
+    private String endDate = "";
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp("closeprice", ticker);
+        closePriceCacheFilter = new ClosePriceCacheFilter();
+        resourceInfo = mock(ResourceInfo.class);
+        when(resourceInfo.getResourceMethod()).thenReturn(ClosePriceService.class.getMethod("getClosePrice", String.class, String.class, String.class));
+        closePriceCacheFilter.setResourceInfo(resourceInfo);
+
+        cacheService = new CacheService<>();
+        cacheService.init();
+        containerRequestContext = mock(ContainerRequestContext.class);
+        containerResponseContext = mock(ContainerResponseContext.class);
+        closePriceCacheFilter.setCacheService(cacheService);
+
+        // Mock uriInfo.
+        UriInfo uriInfo = mock(UriInfo.class);
+        MultivaluedMap<String, String> pathParameters = new MultivaluedHashMap<>();
+        pathParameters.putSingle("ticker", ticker);
+        when(uriInfo.getPathParameters()).thenReturn(pathParameters);
+        MultivaluedMap<String, String> queryParameters = new MultivaluedHashMap<>();
+        queryParameters.putSingle("startDate", startDate);
+        queryParameters.putSingle("endDate", endDate);
+        when(uriInfo.getQueryParameters()).thenReturn(queryParameters);
+        when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
+        when(containerRequestContext.getMediaType()).thenReturn(MediaType.APPLICATION_JSON_TYPE);
+    }
+
+    @Test
+    public void getCachedPriceFromCache() {
+        // GIVEN
+        CachedEntity<Price> priceToCache = CachedEntity.<Price>builder()
+                .entity(Price.builder()
+                        .ticker(ticker)
+                        .dateClose(dateCloseList)
+                        .build())
+                .build();
+        cacheService.put(closePriceCacheFilter.generateHashCode(ticker, startDate, endDate), priceToCache);
+
+        // WHEN
+        closePriceCacheFilter.filter(containerRequestContext);
+
+        // THEN
+        verify(containerRequestContext, times(1)).abortWith(any());
+    }
+}

--- a/stock-consultant/src/test/java/com/emeraldhieu/closeprice/ClosePriceServiceTest.java
+++ b/stock-consultant/src/test/java/com/emeraldhieu/closeprice/ClosePriceServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.emeraldhieu.AbstractServiceTest;
-import com.emeraldhieu.cache.CacheService;
 import com.emeraldhieu.errorhandler.ErrorHandlingService;
 
 import okhttp3.OkHttpClient;
@@ -19,16 +18,13 @@ import okhttp3.OkHttpClient;
 public class ClosePriceServiceTest extends AbstractServiceTest {
 
     private ClosePriceService closePriceService;
-    private CacheService cacheService;
     private ErrorHandlingService errorHandlingService;
     private String ticker = "FB";
 
     @Before
     public void setUp() {
-        cacheService = new DummyCacheService();
         errorHandlingService = new ErrorHandlingService();
         closePriceService = new ClosePriceService();
-        closePriceService.setCacheService(cacheService);
         closePriceService.setErrorHandlingService(errorHandlingService);
     }
 

--- a/stock-consultant/src/test/java/com/emeraldhieu/multidmas/MultiDmaServiceTest.java
+++ b/stock-consultant/src/test/java/com/emeraldhieu/multidmas/MultiDmaServiceTest.java
@@ -19,7 +19,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import com.emeraldhieu.AbstractServiceTest;
-import com.emeraldhieu.cache.CacheService;
 import com.emeraldhieu.errorhandler.ErrorHandlingService;
 import com.emeraldhieu.twohundreddma.DmaService;
 
@@ -33,16 +32,12 @@ import okhttp3.ResponseBody;
 
 public class MultiDmaServiceTest extends AbstractServiceTest {
     private DmaService dmaService;
-    private CacheService cacheService;
     private ErrorHandlingService errorHandlingService;
     private MultiDmaService multiDmaService;
 
     @Before
     public void setUp() {
         multiDmaService = new MultiDmaService();
-
-        cacheService = new DummyCacheService();
-        multiDmaService.setCacheService(cacheService);
 
         errorHandlingService = new ErrorHandlingService();
         multiDmaService.setErrorHandlingService(errorHandlingService);

--- a/stock-consultant/src/test/java/com/emeraldhieu/twohundreddma/DmaCacheFilterTest.java
+++ b/stock-consultant/src/test/java/com/emeraldhieu/twohundreddma/DmaCacheFilterTest.java
@@ -1,0 +1,72 @@
+package com.emeraldhieu.twohundreddma;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.emeraldhieu.cache.CacheService;
+import com.emeraldhieu.cache.CachedEntity;
+import com.emeraldhieu.closeprice.CacheFilterTest;
+import com.emeraldhieu.closeprice.ClosePrice;
+
+public class DmaCacheFilterTest extends CacheFilterTest {
+    private DmaCacheFilter dmaCacheFilter;
+    private ResourceInfo resourceInfo;
+    private CacheService<ClosePrice.Price> cacheService;
+    private ContainerRequestContext containerRequestContext;
+    private String ticker = "FB";
+    private String startDate = "2012-05-18";
+    private String endDate = "2012-12-04";
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp("dma", ticker);
+        dmaCacheFilter = new DmaCacheFilter();
+        resourceInfo = mock(ResourceInfo.class);
+        when(resourceInfo.getResourceMethod()).thenReturn(DmaService.class.getMethod("get200DayMovingAverage", String.class, String.class));
+        dmaCacheFilter.setResourceInfo(resourceInfo);
+
+        cacheService = new CacheService<>();
+        cacheService.init();
+        containerRequestContext = mock(ContainerRequestContext.class);
+        dmaCacheFilter.setCacheService(cacheService);
+
+        // Mock uriInfo.
+        UriInfo uriInfo = mock(UriInfo.class);
+        MultivaluedMap<String, String> pathParameters = new MultivaluedHashMap<>();
+        pathParameters.putSingle("ticker", ticker);
+        when(uriInfo.getPathParameters()).thenReturn(pathParameters);
+        MultivaluedMap<String, String> queryParameters = new MultivaluedHashMap<>();
+        queryParameters.putSingle("startDate", startDate);
+        when(uriInfo.getQueryParameters()).thenReturn(queryParameters);
+        when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
+        when(containerRequestContext.getMediaType()).thenReturn(MediaType.APPLICATION_JSON_TYPE);
+    }
+
+    @Test
+    public void getCachedPriceFromCache() {
+        // GIVEN
+        CachedEntity<ClosePrice.Price> priceToCache = CachedEntity.<ClosePrice.Price>builder()
+                .entity(ClosePrice.Price.builder()
+                        .ticker(ticker)
+                        .dateClose(dateCloseList)
+                        .build())
+                .build();
+        cacheService.put(dmaCacheFilter.generateHashCode(ticker, startDate, endDate), priceToCache);
+
+        // WHEN
+        dmaCacheFilter.filter(containerRequestContext);
+
+        // THEN
+        verify(containerRequestContext, times(1)).abortWith(any());
+    }
+}

--- a/stock-consultant/src/test/java/com/emeraldhieu/twohundreddma/DmaServiceTest.java
+++ b/stock-consultant/src/test/java/com/emeraldhieu/twohundreddma/DmaServiceTest.java
@@ -10,8 +10,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.emeraldhieu.AbstractServiceTest;
-import com.emeraldhieu.cache.CacheService;
-import com.emeraldhieu.closeprice.ClosePriceService;
 import com.emeraldhieu.errorhandler.ErrorHandlingService;
 
 import okhttp3.OkHttpClient;
@@ -19,22 +17,15 @@ import okhttp3.OkHttpClient;
 public class DmaServiceTest extends AbstractServiceTest {
 
     private DmaService dmaService;
-    private CacheService cacheService;
     private ErrorHandlingService errorHandlingService;
-    private ClosePriceService closePriceService;
     private String ticker = "FB";
 
     @Before
     public void setUp() {
         dmaService = new DmaService();
-        cacheService = new DummyCacheService();
-        dmaService.setCacheService(cacheService);
 
         errorHandlingService = new ErrorHandlingService();
         dmaService.setErrorHandlingService(errorHandlingService);
-
-        closePriceService = new ClosePriceService();
-        dmaService.setClosePriceService(closePriceService);
     }
 
     @Test


### PR DESCRIPTION
Seperating caching in closePriceService and dmaService

This could be tested by running 2 these requests:
1) Run closePrice to cache dateCloses from startDate to endDate
~ http://localhost:8080/.rest/api/v2/FB/closePrice?startDate=2012-05-18&endDate=2012-12-04
2) Run 200dma to retrieve cache of dateCloses from startDate to 200 days after
~ http://localhost:8080/.rest/api/v2/FB/200dma?startDate=2012-05-18

* caching multiDmaService will be done later